### PR TITLE
compat(ACF): Replace structValueArray function

### DIFF
--- a/models/PlaywrightMixins.cfm
+++ b/models/PlaywrightMixins.cfm
@@ -70,7 +70,10 @@
 
 	public string function route() {
 		var baseURL = CGI.HTTPS == "on" ? "https://" : "http://" & CGI.HTTP_HOST;
-		var pathArray = structValueArray( arguments );
+		var pathArray = [];
+		for ( var currentKey in arguments ){
+			pathArray.append( arguments[currentKey] );
+		}
 		return variables.javaPaths.get( baseURL, javacast( "String[]", pathArray ) ).toString();
 	}
 


### PR DESCRIPTION
The `structValueArray` function is not available in ACF.